### PR TITLE
feat: Configure project for Render deployment with Gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn run:app

--- a/README.md
+++ b/README.md
@@ -93,3 +93,16 @@ A Flask-RESTful API for managing products and searching for store locations. It 
             *   `radius` (optional): Search radius in meters (default is 5000).
             *   Example: `GET /locations?name=CoffeeShop&location=New%20York&radius=1000`
     *   Response: `200 OK` with `{"data": result}` containing location information. `400 Bad Request` if required parameters are missing.
+
+## Deploying to Render
+
+To deploy this application to Render, follow these steps:
+
+1.  **Create a new Web Service on Render.**
+2.  **Connect your Git repository.**
+3.  **Set the Build Command:** `pip install -r requirements.txt`
+4.  **Set the Start Command:** `gunicorn run:app`
+5.  **Configure environment variables** as needed (e.g., `FLASK_ENV=production`, database URLs, API keys).
+6.  **Deploy!**
+
+Render will automatically detect the `Procfile` and use the `web` process type with the Gunicorn command.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ googlemaps
 sentence_transformers
 faiss-cpu
 numpy<2
+gunicorn

--- a/run.py
+++ b/run.py
@@ -7,6 +7,3 @@ load_dotenv()
 flask_env = os.getenv('FLASK_ENV', 'development')
 
 app = create_app(flask_env)
-
-if __name__ == "__main__":
-    app.run(debug=True)


### PR DESCRIPTION
This commit introduces the necessary changes to deploy your application to Render using the Gunicorn WSGI server.

Changes include:
- Added `gunicorn` to `requirements.txt`.
- Created a `Procfile` to specify the command for Render to run the web service (`web: gunicorn run:app`).
- Removed the development `app.run()` call from `run.py` as Gunicorn will manage the application server in production.
- Updated `README.md` with instructions on how to deploy your application to Render, including build and start commands.