### PR TITLE
feat: Configure app for Render production deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,18 @@
 services:
   - type: web
-    name: my-app
+    name: brite-shopping-app # Changed from my-app
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "gunicorn run:app"
+    healthCheckPath: /health # Added health check path
+    envVars:
+      - key: FLASK_ENV
+        value: production
+      - key: MONGO_URI
+        # Ensure this is set in Render dashboard secrets
+        # Example: mongodb+srv://<user>:<password>@<cluster-uri>/<dbname>
+        value: "" # Placeholder - set actual value in Render dashboard
+      - key: MONGO_DATABASE_NAME
+        # Ensure this is set in Render dashboard secrets
+        value: "" # Placeholder - set actual value in Render dashboard
+      # Add other environment variables your app might need

--- a/run.py
+++ b/run.py
@@ -1,9 +1,14 @@
 import os
 from app import create_app
 from dotenv import load_dotenv
-load_dotenv()
+from flask import jsonify # Import jsonify
 
+load_dotenv()
 
 flask_env = os.getenv('FLASK_ENV', 'development')
 
 app = create_app(flask_env)
+
+@app.route('/health')
+def health_check():
+    return jsonify({"status": "healthy"}), 200


### PR DESCRIPTION
This commit introduces several changes to prepare the application for production deployment on Render:

- Updated `render.yaml`:
    - Renamed service to `brite-shopping-app`.
    - Set `FLASK_ENV` to `production`.
    - Added `MONGO_URI` and `MONGO_DATABASE_NAME` environment variables (to be configured securely in Render dashboard).
    - Configured `healthCheckPath: /health` for service monitoring.

- Added a `/health` endpoint in `run.py` for Render health checks.

- Reviewed `.gitignore` and confirmed it's suitable.

- Noted considerations for selecting an adequate Render instance type due to AI model dependencies (`faiss-cpu`, `sentence_transformers`).